### PR TITLE
Only typecheck functions of queried package

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,8 @@ func Run(filename string, offset int64) (*Doc, error) {
 		return nil, fmt.Errorf("gogetdoc: couldn't get package for %s: %s", filename, err.Error())
 	}
 	conf := &loader.Config{
-		ParserMode: parser.ParseComments,
+		ParserMode:          parser.ParseComments,
+		TypeCheckFuncBodies: func(pkg string) bool { return pkg == bp.ImportPath },
 	}
 	conf.Import(bp.ImportPath)
 	lprog, err := conf.Load()


### PR DESCRIPTION
By not typechecking the function bodies of imported packages, we gain a
performance increase without losing relevant information.

For a simple package that only imports the "bytes" package, this
improvement reduces the query time from ~0.5s to ~0.2s