### PR TITLE
Allow errors when parsing package

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,16 @@ func Run(ctx *build.Context, filename string, offset int64) (*Doc, error) {
 		Build:               ctx,
 		ParserMode:          parser.ParseComments,
 		TypeCheckFuncBodies: func(pkg string) bool { return pkg == bp.ImportPath },
+		AllowErrors:         true,
+	}
+
+	seenError := false
+	conf.TypeChecker.Error = func(err error) {
+		if seenError {
+			return
+		}
+		fmt.Fprintln(os.Stderr, err)
+		seenError = true
 	}
 	conf.ImportWithTests(bp.ImportPath)
 	lprog, err := conf.Load()


### PR DESCRIPTION
go/parser has good support for recovering from parse errors, and
go/types has good support for continuing despite type errors. By setting
AllowErrors, we will get a partially type-checked package.

In the best case, this will allow us to query documentation even if a
function is called with the wrong arguments, or when having unbalanced
parentheses because we're in the middle of writing code.

In the worst case, for example because of a missing import or an
undefined function, it'll behave as before and fail to show the
documentation for an identifier.

Additionally, we define our own error printing function and only print
the first encountered error. By default, go/types displays all errors,
which can lead to a lot of "invalid type" errors when an import is
missing that is being referred to many times.