### PR TITLE
Don't crash if file failed to parse completely

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,9 @@ func FileFromProgram(prog *loader.Program, name string) *token.File {
 	for _, info := range prog.AllPackages {
 		for _, astFile := range info.Files {
 			tokFile := prog.Fset.File(astFile.Pos())
+			if tokFile == nil {
+				continue
+			}
 			tokName := tokFile.Name()
 			if runtime.GOOS == "windows" {
 				tokName = filepath.ToSlash(tokName)


### PR DESCRIPTION
Sometimes, even go/parser can't recover. In that case, we end up with an
incomplete file set. It might be nice to specifically detect this case
and provide a more useful error, but for now it's good enough not to
crash and just complain that the file wasn't found in the package.