### PR TITLE
Feat: Add local package support

### DIFF
--- a/testdata/hello.go
+++ b/testdata/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}


### PR DESCRIPTION
The current version of gogetdoc can't work for a local package,
This means if your code is not put in GOPATH, then you can't get any
help with gogetdoc. It's so bad.

I tried to fix it via this commit and looks work fine on my MacBook.
If it is also useful for others, please approve my pull request.

This commit changes the current behavior and adds a function named
`importLocalPackage` which can import local packages, when
`buildutil.ContainingPackage(...)` failed, `importLocalPackage` will
be called instead of return an error.

This PR should close #14.