### PR TITLE
Fix signature of ParseFile function

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,11 +110,10 @@ func Load(filename string, offset int, modified bool) (*packages.Package, []ast.
 	}
 	// Adapted from: https://github.com/ianthehat/godef
 	fstat, fstatErr := os.Stat(filename)
-	parseFile := func(fset *token.FileSet, fname string) (*ast.File, error) {
+	parseFile := func(fset *token.FileSet, fname string, filedata []byte) (*ast.File, error) {
 		var (
-			filedata []byte
-			err      error
-			s        os.FileInfo
+			err error
+			s   os.FileInfo
 		)
 		isInputFile := false
 		if filename == fname {
@@ -125,13 +124,16 @@ func Load(filename string, offset int, modified bool) (*packages.Package, []ast.
 			isInputFile = os.SameFile(fstat, s)
 		}
 
-		if b, ok := archive[fname]; ok {
-			filedata = b
-		} else {
-			if filedata, err = ioutil.ReadFile(fname); err != nil {
-				return nil, fmt.Errorf("cannot read %s: %v", fname, err)
+		if filedata == nil {
+			if b, ok := archive[fname]; ok {
+				filedata = b
+			} else {
+				if filedata, err = ioutil.ReadFile(fname); err != nil {
+					return nil, fmt.Errorf("cannot read %s: %v", fname, err)
+				}
 			}
 		}
+
 		mode := parser.ParseComments
 		if isInputFile && debugAST {
 			mode |= parser.Trace


### PR DESCRIPTION
The signature of ParseFile function has been changed from `/x/tools/go/packages` in the following commit: https://github.com/golang/tools/commit/2f1727f1b37d7d257665debc72d4ae0b8e449748

Currently, we can't run `go install` due to the incorrect function signature. This commit attempts to fix the problem