### PR TITLE
search package imports if node not found in current package

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func Run(filename string, offset int, overlay map[string][]byte) (*Doc, error) {
 	return DocFromNodes(pkg, nodes)
 }
 
-func ObjectFound(pkg *packages.Package, node *ast.Ident) bool {
+func objectFound(pkg *packages.Package, node *ast.Ident) bool {
 	if obj := pkg.TypesInfo.ObjectOf(node); obj != nil {
 		return true
 	}
@@ -229,7 +229,7 @@ func DocFromNodes(pkg *packages.Package, nodes []ast.Node) (*Doc, error) {
 			return PackageDoc(pkg, ImportPath(node))
 		case *ast.Ident:
 			// if we can't find the object denoted by the identifier, keep searching)
-			if !ObjectFound(pkg, node) {
+			if !objectFound(pkg, node) {
 				continue
 			}
 			return IdentDoc(node, pkg.TypesInfo, pkg)

--- a/main.go
+++ b/main.go
@@ -218,6 +218,11 @@ func DocFromNodes(pkg *packages.Package, nodes []ast.Node) (*Doc, error) {
 		case *ast.Ident:
 			// if we can't find the object denoted by the identifier, keep searching)
 			if obj := pkg.TypesInfo.ObjectOf(node); obj == nil {
+				for _, imp := range pkg.Imports {
+					if obj := imp.TypesInfo.ObjectOf(node); obj == nil {
+						continue
+					}
+				}
 				continue
 			}
 			return IdentDoc(node, pkg.TypesInfo, pkg)


### PR DESCRIPTION
For some reason, in my test files imported structs were not being found.
Searching the imports as well fixes this issue for me.
Removing this ObjectOf() check entirely also seems to work for me.  

Why is this check here in the first place?