### PR TITLE
Fix #52

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -143,3 +143,22 @@ func setup(cfg *packages.Config) func() {
 		setEnv(originalEnv)
 	}
 }
+
+func TestIssue52(t *testing.T) {
+	filename := filepath.Join(".", "testdata", "issue52", "main.go")
+	for _, test := range []struct {
+		Pos int
+		Doc string
+	}{
+		{80, "V this works\n"},
+		{82, "Foo this doesn't work but should\n"},
+	} {
+		doc, err := Run(filename, test.Pos, nil)
+		if err != nil {
+			t.Fatalf("issue52, pos %d: %v", test.Pos, err)
+		}
+		if doc.Doc != test.Doc {
+			t.Errorf("issue52, pos %d, invalid decl: want %q, got %q", test.Pos, test.Doc, doc.Doc)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -145,20 +145,36 @@ func setup(cfg *packages.Config) func() {
 }
 
 func TestIssue52(t *testing.T) {
-	filename := filepath.Join(".", "testdata", "issue52", "main.go")
-	for _, test := range []struct {
-		Pos int
-		Doc string
-	}{
-		{80, "V this works\n"},
-		{82, "Foo this doesn't work but should\n"},
-	} {
-		doc, err := Run(filename, test.Pos, nil)
-		if err != nil {
-			t.Fatalf("issue52, pos %d: %v", test.Pos, err)
-		}
-		if doc.Doc != test.Doc {
-			t.Errorf("issue52, pos %d, invalid decl: want %q, got %q", test.Pos, test.Doc, doc.Doc)
-		}
+	dir := filepath.Join(".", "testdata", "issue52")
+	mods := []packagestest.Module{
+		{Name: "issue52", Files: packagestest.MustCopyFileTree(dir)},
 	}
+	packagestest.TestAll(t, func(t *testing.T, exporter packagestest.Exporter) {
+		if exporter == packagestest.Modules && !modulesSupported() {
+			t.Skip("Skipping modules test on", runtime.Version())
+		}
+		exported := packagestest.Export(t, exporter, mods)
+		defer exported.Cleanup()
+
+		teardown := setup(exported.Config)
+		defer teardown()
+
+		filename := exported.File("issue52", "main.go")
+
+		for _, test := range []struct {
+			Pos int
+			Doc string
+		}{
+			{64, "V this works\n"},
+			{66, "Foo this doesn't work but should\n"},
+		} {
+			doc, err := Run(filename, test.Pos, nil)
+			if err != nil {
+				t.Fatalf("issue52, pos %d: %v", test.Pos, err)
+			}
+			if doc.Doc != test.Doc {
+				t.Errorf("issue52, pos %d, invalid decl: want %q, got %q", test.Pos, test.Doc, doc.Doc)
+			}
+		}
+	})
 }

--- a/testdata/issue52/first/first.go
+++ b/testdata/issue52/first/first.go
@@ -1,6 +1,6 @@
 package first
 
-import "github.com/zmb3/issue52/first/second"
+import "issue52/first/second"
 
 //V this works
 var V second.T

--- a/testdata/issue52/first/first.go
+++ b/testdata/issue52/first/first.go
@@ -1,0 +1,6 @@
+package first
+
+import "github.com/zmb3/issue52/first/second"
+
+//V this works
+var V second.T

--- a/testdata/issue52/first/second/second.go
+++ b/testdata/issue52/first/second/second.go
@@ -1,0 +1,6 @@
+package second
+
+type T struct{}
+
+//Foo this doesn't work but should
+func (t T) Foo() {}

--- a/testdata/issue52/go.mod
+++ b/testdata/issue52/go.mod
@@ -1,0 +1,1 @@
+module github.com/zmb3/issue52

--- a/testdata/issue52/go.mod
+++ b/testdata/issue52/go.mod
@@ -1,1 +1,0 @@
-module github.com/zmb3/issue52

--- a/testdata/issue52/main.go
+++ b/testdata/issue52/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/zmb3/issue52/first"
+	"issue52/first"
 )
 
 func main() {

--- a/testdata/issue52/main.go
+++ b/testdata/issue52/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/zmb3/issue52/first"
+)
+
+func main() {
+	first.V.Foo()
+}


### PR DESCRIPTION
`pathEnclosingInterval ` is searching only through top level package and its imports. If the symbol in question is located further down the dependency tree, it's not found. Fix this by recursively searching through imports instead.

Also refactored the method by removing unused return value, which cleaned up code a bit.

Fixes #52 